### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ numpy==1.16.1
 opencv-python==4.0.0.21
 pandas==0.24.1
 Pillow==5.4.1
-pkg-resources==0.0.0
+# pkg-resources==0.0.0
 protobuf==3.6.1
 pyparsing==2.3.1
 python-dateutil==2.8.0


### PR DESCRIPTION
Removed the pkg-resources dependency as is likely that this is a bug. By trying to install the requirements in my machine with Ubuntu 18.04, it does not work because of this dependency. I attach the following link why I think this line should be removed.

https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command